### PR TITLE
Cleanr

### DIFF
--- a/R/import_jhu_data.R
+++ b/R/import_jhu_data.R
@@ -26,5 +26,7 @@ import_jhu_data <- function(type){
   
   if(type == "deaths")
     df <- dplyr::rename(df, deaths = cases, daily_deaths = daily_cases)
+  
+  return(df)
 }
 

--- a/R/import_jhu_data.R
+++ b/R/import_jhu_data.R
@@ -21,5 +21,10 @@ import_jhu_data <- function(type){
                                                                         `Country/Region` = "c"))
   df <- reshape_jhu_covid(df)
 
+  if(type == "recoveries")
+    df <- dplyr::rename(df, recoveries = cases, daily_recoveries = daily_cases)
+  
+  if(type == "deaths")
+    df <- dplyr::rename(df, deaths = cases, daily_deaths = daily_cases)
 }
 

--- a/R/import_jhu_data.R
+++ b/R/import_jhu_data.R
@@ -16,7 +16,9 @@ import_jhu_data <- function(type){
                            type == "recoveries" ~ tsRecov,
                            type == "deaths" ~ tsDeaths)
 
-  df <- readr::read_csv(file.path(paste0(jhuRepo, type)))
+  df <- readr::read_csv(file.path(paste0(jhuRepo, type)), col_types = c(.default = "d",
+                                                                        `Province/State` = "c",
+                                                                        `Country/Region` = "c"))
   df <- reshape_jhu_covid(df)
 
 }

--- a/R/import_jhu_data.R
+++ b/R/import_jhu_data.R
@@ -12,11 +12,11 @@ import_jhu_data <- function(type){
   stopifnot(length(type) != 0 & type %in% c("cases", "recoveries", "deaths"))
 
   # Select the type of data to pull
-  type <- dplyr::case_when(type == "cases" ~ tsCases,
+  type_url <- dplyr::case_when(type == "cases" ~ tsCases,
                            type == "recoveries" ~ tsRecov,
                            type == "deaths" ~ tsDeaths)
 
-  df <- readr::read_csv(file.path(paste0(jhuRepo, type)), col_types = c(.default = "d",
+  df <- readr::read_csv(file.path(paste0(jhuRepo, type_url)), col_types = c(.default = "d",
                                                                         `Province/State` = "c",
                                                                         `Country/Region` = "c"))
   df <- reshape_jhu_covid(df)

--- a/R/pull_jhu_covid.R
+++ b/R/pull_jhu_covid.R
@@ -16,8 +16,8 @@
 pull_jhu_covid <- function() {
 
   cases <- import_jhu_data("cases")
-  recover <- import_jhu_data("recoveries") %>%dplyr::rename(recoveries = cases, daily_recoveries = daily_cases)
-  deaths <- import_jhu_data("deaths") %>% dplyr::rename(deaths = cases, daily_deaths = daily_cases)
+  recover <- import_jhu_data("recoveries")
+  deaths <- import_jhu_data("deaths") 
 
   df <- dplyr::left_join(cases, recover) %>%
     dplyr::left_join(deaths ) %>%

--- a/R/pull_jhu_covid.R
+++ b/R/pull_jhu_covid.R
@@ -19,8 +19,8 @@ pull_jhu_covid <- function() {
   recover <- import_jhu_data("recoveries")
   deaths <- import_jhu_data("deaths") 
 
-  df <- dplyr::left_join(cases, recover) %>%
-    dplyr::left_join(deaths ) %>%
+  df <- dplyr::left_join(cases, recover, by = c("countryname", "date")) %>%
+    dplyr::left_join(deaths, by = c("countryname", "date")) %>%
     dplyr::arrange(countryname, date) %>%
     dplyr::group_by(countryname) %>%
     dplyr::mutate(first_case = first_time_flag(cases, 1),


### PR DESCRIPTION
- clean up import by specifying `col_types` so no output in console
- moved the renaming of recoveries and deaths to `import_jhu_data()` so it can be used as stand alone function